### PR TITLE
Updated topMenu useEffects to ensure it only runs once

### DIFF
--- a/laguna-pools-frontend/src/components/topMenu.tsx
+++ b/laguna-pools-frontend/src/components/topMenu.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import React, {useEffect, useState, useRef } from 'react';
 import {AppBar, Box, Button, Toolbar} from '@mui/material';
 import {ExitToApp} from '@mui/icons-material';
 import {Component} from '../utils/componentsEnum';
@@ -16,6 +16,7 @@ const TopMenu: React.FC<TopMenuProps> = ({selectHandler, onLogout}) => {
     const [anchorEl] = useState<null | HTMLElement>(null);
     const open = Boolean(anchorEl);
     const [userRoles, setUserRoles] = useState<string[]>([]);
+    const effectRan = useRef(false);
 
     const hasRole = (role: string) => {
         return userRoles.includes(role);
@@ -25,10 +26,18 @@ const TopMenu: React.FC<TopMenuProps> = ({selectHandler, onLogout}) => {
         selectHandler(Component.CONTROL_PANEL);
     };
 
+
+
     useEffect(() => {
-        UserApiService.getRoles().then(r => {
-            setUserRoles(r.data.roles);
-        }).catch(err => console.error(err));
+        if (effectRan.current === false) {
+            UserApiService.getRoles().then(r => {
+                setUserRoles(r.data.roles);
+            }).catch(err => console.error(err));
+
+            return () => {
+                effectRan.current = true;
+            };
+        }
     }, []);
 
     return (


### PR DESCRIPTION
this PR adresses the following
 
- The TopMenu component was making duplicate API calls to the 'get_user_roles' endpoint.
- The problem likely occurred due to the component re-rendering or remounting, triggering multiple API calls when only one was needed.

by:

- Modifying TopMenu component to prevent duplicate API calls for user roles
- Implemented useRef to track if the effect has already run
- Ensures get_user_roles is called only once on component mount
- Prevents unnecessary API calls on re-renders, improving performance

I have prepared some unit tests for this if that is something that you would want to be added. 